### PR TITLE
Potential fix for code scanning alert no. 21: Missing global error handler

### DIFF
--- a/WebGoat/Web.config
+++ b/WebGoat/Web.config
@@ -50,7 +50,7 @@ http://msdn2.microsoft.com/en-us/library/b5ysx397.aspx
       </assemblies>
     </compilation>
     <!-- show detailed error messages -->
-    <customErrors mode="Off" />
+    <customErrors mode="RemoteOnly" />
     <!-- set up users -->
     <authentication mode="Forms">
       <forms name="customer_login" timeout="30" loginUrl="~/WebGoatCoins/CustomerLogin.aspx" requireSSL="false" protection="All" path="/">


### PR DESCRIPTION
Potential fix for [https://github.com/GavWall/advanced-security-csharp/security/code-scanning/21](https://github.com/GavWall/advanced-security-csharp/security/code-scanning/21)

To address the issue, we will modify the `Web.config` file to set the `customErrors` mode to `RemoteOnly`. This ensures that detailed error information is only displayed when the application is accessed locally, while a generic error page is shown to remote users. This is a secure and practical configuration for most scenarios. 

Alternatively, if the application requires custom error handling, an `Application_Error` method can be implemented in the `global.asax.cs` file. However, since the `global.asax.cs` file is not provided, we will focus on fixing the `Web.config` file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
